### PR TITLE
Move blockmove initialization to uicomponents module

### DIFF
--- a/gaphor/SysML/blocks/__init__.py
+++ b/gaphor/SysML/blocks/__init__.py
@@ -1,4 +1,3 @@
-import gaphor.SysML.blocks.blockmove
 import gaphor.SysML.blocks.connectors
 import gaphor.SysML.blocks.datatype
 import gaphor.SysML.blocks.group

--- a/gaphor/SysML/uicomponents.py
+++ b/gaphor/SysML/uicomponents.py
@@ -1,0 +1,4 @@
+# ruff: noqa: F401
+
+import gaphor.SysML.blocks.blockmove
+import gaphor.SysML.propertypages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ gaphor = "gaphor.main:main"
 [tool.poetry.plugins."gaphor.modules"]
 "general_ui_components" = "gaphor.diagram.general.uicomponents"
 "uml_ui_components" = "gaphor.UML.uicomponents"
-"sysml_property_pages" = "gaphor.SysML.propertypages"
+"sysml_property_pages" = "gaphor.SysML.uicomponents"
 "c4model_property_pages" = "gaphor.C4Model.propertypages"
 
 [tool.poetry.plugins."gaphor.services"]


### PR DESCRIPTION
The blockmove module indirectly import Gdk. That should only happen if a uit session is loaded.

`blockmove` indirectly loads `GDK`, which it should not do. The idea is that you can use pretty much all functionality of Gaphor (e.g. from a notebook) without a GUI, and GUI libraries.

You need to run `poetry install`, because one of the entry points changed in `pyproject.toml`.
